### PR TITLE
Fix typo in options.md for FOTA instrucitons

### DIFF
--- a/options.md
+++ b/options.md
@@ -100,7 +100,7 @@ to enable FOTA then add the following lines inside your `config.json`:
 
 ```
 "image": {
-  "fota": false
+  "fota": true
 }
 ```
 


### PR DESCRIPTION
This change is related to https://github.com/ARMmbed/target-nordic-nrf51822/pull/6, thanks to @jacobrosenthal for spotting it.

Note that @jacobrosenthal has submitted a pull request, but before his contributions can be merged he must sign a contributor's agreement. However, because this is a trivial change, I am submitting the same patch to resolve the inaccuracy in `options.md` quickly.

@pan-
